### PR TITLE
Fix MySQL requirement

### DIFF
--- a/github_requirements.txt
+++ b/github_requirements.txt
@@ -1,1 +1,2 @@
 -e git+https://github.com/edx/opaque-keys.git@33f2b099e92957046a866a9b6d48a71c484bb475#egg=opaque_keys
+http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-1.2.2.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ python-dateutil
 pyyaml
 python-gnupg==0.3.6
 pymongo
-mysql-connector-python==1.2.2


### PR DESCRIPTION
For some reason pip is no longer able to install this requirement.

Changing to an HTTP URL appears to resolve the issue.

@brianhw @e0d 
