### PR TITLE
Support different password for RDS on edge.

### DIFF
--- a/exporter/config.py
+++ b/exporter/config.py
@@ -96,6 +96,7 @@ def update_environments(config):
 
             # different settings for edge
             if env == 'edge':
+                data['sql_password'] = tokens.get('rds_pass_edge')
                 data['mongo_user'] = tokens.get('mongo_user_edge')
                 data['mongo_password'] = tokens.get('mongo_pass_edge')
 


### PR DESCRIPTION
The code had assumed that the same password was used for RDS on edge and prod.  This now requires a separate entry for a password for edge RDS.

@mulby @HassanJaveed84 
