### PR TITLE
Remove In-Course Reverification

### DIFF
--- a/exporter/tasks.py
+++ b/exporter/tasks.py
@@ -336,21 +336,6 @@ class GeneratedCertificateTask(CourseTask, SQLTask):
     """
 
 
-class InCourseReverificationTask(CourseTask, SQLTask):
-    NAME = 'verify_student_verificationstatus'
-    SQL = """
-    SELECT vs.timestamp,
-           vs.status,
-           vc.course_id,
-           vc.checkpoint_location,
-           vs.user_id
-    FROM verify_student_verificationstatus AS vs
-    LEFT JOIN verify_student_verificationcheckpoint AS vc ON vs.checkpoint_id=vc.id
-    WHERE vc.course_id='{course}'
-    ORDER BY vs.timestamp ASC
-    """
-
-
 class AuthUserTask(CourseTask, SQLTask):
     NAME = 'auth_user'
     SQL = """


### PR DESCRIPTION
# [TNL-6126](https://openedx.atlassian.net/browse/TNL-6126)

In course reverification is going away for good, see ticket for details. The database table referenced herein will be dropped on production shortly.

@thallada and @brianhw - can you be my reviewers? I'm also unsure how to go about deploying this after it gets merged, but that'll need to happen before https://github.com/edx/edx-platform/pull/14588 lands.