### PR TITLE
Added credit eligibility.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Diana Huang <dkh@edx.org>
 Andy Armstrong <andya@edx.org>
 Will Daly <will@edx.org>
 Eric Fischer <efischer@edx.org>
+Dennis Jen <djen@edx.org>

--- a/exporter/tasks.py
+++ b/exporter/tasks.py
@@ -527,7 +527,7 @@ class CourseCreditEligibilityTask(CourseTask, SQLTask):
            ce.modified,
            ce.username,
            ce.deadline,
-           cc.course_key
+           cc.course_key as course_id
     FROM credit_crediteligibility AS ce
     LEFT JOIN credit_creditcourse AS cc on ce.course_id=cc.id
     WHERE cc.course_key='{course}'

--- a/exporter/tasks.py
+++ b/exporter/tasks.py
@@ -987,4 +987,5 @@ DEFAULT_TASKS = [
     WorkflowAssessmentWorkflowTask,
     WorkflowAssessmentWorkflowStepTask,
     StudentAnonymousUserIDTask,
+    CourseCreditEligibilityTask,
 ]

--- a/exporter/tasks.py
+++ b/exporter/tasks.py
@@ -518,6 +518,23 @@ class StudentAnonymousUserIDTask(CourseTask, SQLTask):
     WHERE course_id="{course}"
     """
 
+
+class CourseCreditEligibilityTask(CourseTask, SQLTask):
+    NAME = 'credit_crediteligibility'
+    SQL = """
+    SELECT ce.id,
+           ce.created,
+           ce.modified,
+           ce.username,
+           ce.deadline,
+           cc.course_key,
+    FROM credit_crediteligibility AS ce
+    LEFT JOIN credit_creditcourse AS cc on ce.course_id=cc.id
+    WHERE cc.course_key='{course}'
+    ORDER BY cc.username
+    """
+
+
 # Start ORA2 Tables ==================
 
 class ORA2CourseTask(CourseTask):

--- a/exporter/tasks.py
+++ b/exporter/tasks.py
@@ -527,11 +527,11 @@ class CourseCreditEligibilityTask(CourseTask, SQLTask):
            ce.modified,
            ce.username,
            ce.deadline,
-           cc.course_key,
+           cc.course_key
     FROM credit_crediteligibility AS ce
     LEFT JOIN credit_creditcourse AS cc on ce.course_id=cc.id
     WHERE cc.course_key='{course}'
-    ORDER BY cc.username
+    ORDER BY ce.username
     """
 
 


### PR DESCRIPTION
[EDUCATOR-154](https://openedx.atlassian.net/browse/EDUCATOR-154)

This adds `credit_crediteligibility` to the research data package (or so I hope).  I've documented the fields at https://openedx.atlassian.net/wiki/display/EDUCATOR/Credit+Eligibility.

I don't think there's really way to test this other than running the query on the read replica, which I did.  If there is another way to confirm that this works, please let me know!

I'm looking for two approvals because I don't know what I'm doing. :)

@edx/analytics @efischer19 