### PR TITLE
psutil is used by the exporter jobs.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ pymongo
 python-dateutil
 python-gnupg==0.3.6
 pyyaml
+psutil
 
 # Tests
 coverage==4.3.4


### PR DESCRIPTION
When building the new admin jenkins, the job started with a blank venv and complained about not being able to find this library.