### PR TITLE
Removing reliance on sudo to run admin commands

### DIFF
--- a/exporter/tasks.py
+++ b/exporter/tasks.py
@@ -193,7 +193,7 @@ class DjangoAdminTask(Task):
     VARS = 'CONFIG_ROOT={django_config} SERVICE_VARIANT=lms'
     OUT = '/dev/null'
     CMD = """
-    sudo -E -u {django_user} {variables}
+    {variables}
       {django_admin} {command}
       --settings={django_settings}
       --pythonpath={django_pythonpath}
@@ -932,7 +932,7 @@ class CourseContentTask(CourseTask, DjangoAdminTask):
     VARS = 'CONFIG_ROOT={django_config} SERVICE_VARIANT=cms'
     # Change CMD to use django_cms_settings.
     CMD = """
-    sudo -E -u {django_user} {variables}
+    {variables}
       {django_admin} {command}
       --settings={django_cms_settings}
       --pythonpath={django_pythonpath}
@@ -948,7 +948,7 @@ class OrgEmailOptInTask(OrgTask, DjangoAdminTask):
     ARGS = '{all_organizations} --courses={comma_sep_courses} --email-optin-chunk-size=10000'
     OUT = '{filename}'
     CMD = """
-    sudo -E -u {django_user} {variables}
+    {variables}
       {django_admin} {command}
       --settings={django_settings}
       --pythonpath={django_pythonpath}

--- a/exporter/tests/test_tasks.py
+++ b/exporter/tests/test_tasks.py
@@ -24,7 +24,6 @@ def test_org_email_opt_in_task(mock_execute_shell):
         'other_names': ['the-second-org', 'the-third-org'],
         'courses': ['course-1', 'course-2'],
         'django_config': 'the-django-config',
-        'django_user': 'the-django-user',
         'django_admin': 'the-django-admin',
         'django_settings': 'the-django-setings',
         'django_pythonpath': 'the-django-python-path',

--- a/sample-config.yaml
+++ b/sample-config.yaml
@@ -12,7 +12,6 @@ defaults:
   se_bucket: the-stack-exchange-bucket
   django_admin: ''
   django_pythonpath: ''
-  django_user: the-django-user
   django_settings: django.settings
   django_cms_settings: django.cms.settings
   django_database: the_django_database


### PR DESCRIPTION
The jenkins user does not have sudo access in our new environment.  Lets take out these super user privileges as so far they have not been necessary.  I've already stabilized the branch used on the Admin jenkins server.