### PR TITLE
Fix pipeline acceptance test.

### DIFF
--- a/exporter/config.py
+++ b/exporter/config.py
@@ -84,7 +84,7 @@ def update_environments(config):
 
     # read authentication tokens
     tokens = {}
-    auth_filename = values.get('auth_file').format(WORKSPACE=os.environ['WORKSPACE'])
+    auth_filename = values.get('auth_file', '').format(WORKSPACE=os.environ['WORKSPACE'])
 
     if auth_filename and os.path.exists(auth_filename):
         with open(auth_filename) as auth_file:

--- a/exporter/config.py
+++ b/exporter/config.py
@@ -84,12 +84,12 @@ def update_environments(config):
 
     # read authentication tokens
     tokens = {}
-    log.info('values: %s', values)
-    auth_filename = values.get('auth_file', '').format(WORKSPACE=os.environ['WORKSPACE'])
-
-    if auth_filename and os.path.exists(auth_filename):
-        with open(auth_filename) as auth_file:
-            tokens.update(json.load(auth_file))
+    auth_filename = values.get('auth_file')
+    if auth_filename:
+        auth_filename = auth_filename.format(WORKSPACE=os.environ['WORKSPACE'])
+        if os.path.exists(auth_filename):
+            with open(auth_filename) as auth_file:
+                tokens.update(json.load(auth_file))
 
     # update "known" environments with the values from the auth file.
     # this would not be necessary if the configuration file had all the values

--- a/exporter/config.py
+++ b/exporter/config.py
@@ -84,6 +84,7 @@ def update_environments(config):
 
     # read authentication tokens
     tokens = {}
+    log.info('values: %s', values)
     auth_filename = values.get('auth_file', '').format(WORKSPACE=os.environ['WORKSPACE'])
 
     if auth_filename and os.path.exists(auth_filename):


### PR DESCRIPTION
In test_database_export pipeline acceptance test, the config has the 'auth_file' set to ```None```

This resulted in a failure of the test with error 'NoneType' object has no attribute 'format'. 