### PR TITLE
Estute/inert exporter jobs

### DIFF
--- a/exporter/course_export.py
+++ b/exporter/course_export.py
@@ -63,7 +63,7 @@ def main():
 
         with make_course_directory(config, course) as temp_directory:
             results = export_course_data(config, temp_directory, courses_with_env[course])
-            upload_files(config, temp_directory)
+            # upload_files(config, temp_directory)
 
 def get_courses_with_env(config):
     courses_with_env = {}

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -338,7 +338,7 @@ def _find_all_courses(**kwargs):
 def make_org_directory(config, organization):
     org_dir = config['work_dir']
 
-    prefix = '{0}_'.format(organization)
+    prefix = 'STU_{0}_'.format(organization)
 
     with make_temp_directory(prefix=prefix, directory=org_dir) as temp_dir:
         # create working directory

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -82,9 +82,9 @@ def main(argv=None):
 
         with make_org_directory(config, organization) as destination:
             results = export_organization_data(config, destination)
-            encrypt_files(config, results)
-            archive = archive_directory(config, destination)
-            upload_data(config, archive)
+            # encrypt_files(config, results)
+            # archive = archive_directory(config, destination)
+            # upload_data(config, archive)
 
 
 def export_organization_data(config, destination):

--- a/exporter/tasks.py
+++ b/exporter/tasks.py
@@ -264,60 +264,60 @@ class CopyS3FileTask(Task):
             filename='job_success/_SUCCESS'
         )
 
-        if dry_run:
-            print 'Copy S3 File: {0} to {1}'.format(
-                s3_source_filename,
-                filename)
-        else:
-            # First check to see that the export data was successfully generated
-            # by looking for a marker file for that run. Return a more severe failure,
-            # so that the overall environment dump fails, rather than just the particular
-            # file being copied.
+        # if dry_run:
+            # print 'Copy S3 File: {0} to {1}'.format(
+                # s3_source_filename,
+                # filename)
+        # else:
+            # # First check to see that the export data was successfully generated
+            # # by looking for a marker file for that run. Return a more severe failure,
+            # # so that the overall environment dump fails, rather than just the particular
+            # # file being copied.
 
-            head_command = "aws s3api head-object --bucket {bucket} --key {key}"
+            # head_command = "aws s3api head-object --bucket {bucket} --key {key}"
 
-            marker_command = head_command.format(
-                bucket=kwargs['pipeline_bucket'],
-                key=s3_marker_filename
-            )
+            # marker_command = head_command.format(
+                # bucket=kwargs['pipeline_bucket'],
+                # key=s3_marker_filename
+            # )
 
-            source_command = head_command.format(
-                bucket=kwargs['pipeline_bucket'],
-                key=s3_source_filename
-            )
+            # source_command = head_command.format(
+                # bucket=kwargs['pipeline_bucket'],
+                # key=s3_source_filename
+            # )
 
-            try:
-                log.info("Running command with retries: %s.", marker_command)
-                # Define retries here, to recover from temporary outages when calling S3 to find files.
-                local_kwargs = dict(**kwargs)
-                local_kwargs['max_tries'] = MAX_TRIES_FOR_MARKER_FILE_CHECK
-                execute_shell(marker_command, **local_kwargs)
-            except subprocess.CalledProcessError:
-                error_message = 'Unable to find success marker for export {0}'.format(s3_marker_filename)
-                log.error(error_message)
-                raise FatalTaskError(error_message)
+            # try:
+                # log.info("Running command with retries: %s.", marker_command)
+                # # Define retries here, to recover from temporary outages when calling S3 to find files.
+                # local_kwargs = dict(**kwargs)
+                # local_kwargs['max_tries'] = MAX_TRIES_FOR_MARKER_FILE_CHECK
+                # execute_shell(marker_command, **local_kwargs)
+            # except subprocess.CalledProcessError:
+                # error_message = 'Unable to find success marker for export {0}'.format(s3_marker_filename)
+                # log.error(error_message)
+                # raise FatalTaskError(error_message)
 
-            # Then check that the source file exists.  It's okay if it isn't,
-            # as that will happen when a particular database table is empty.
-            try:
-                log.info("Running command %s.", source_command)
-                execute_shell(source_command, **kwargs)
-            except subprocess.CalledProcessError:
-                log.info('Unable to find %s to copy.', s3_source_filename)
-            else:
-                try:
-                    cmd = 'aws s3 cp s3://{bucket}/{src} {dest}'.format(
-                        bucket=kwargs['pipeline_bucket'],
-                        src=s3_source_filename,
-                        dest=filename
-                    )
-                    # Define retries here, to recover from temporary outages when calling S3 to copy files.
-                    local_kwargs = dict(**kwargs)
-                    local_kwargs['max_tries'] = MAX_TRIES_FOR_COPY_FILE_FROM_S3
-                    execute_shell(cmd, **local_kwargs)
-                except subprocess.CalledProcessError:
-                    log.error('Unable to copy %s to %s', s3_source_filename, filename)
-                    raise
+            # # Then check that the source file exists.  It's okay if it isn't,
+            # # as that will happen when a particular database table is empty.
+            # try:
+                # log.info("Running command %s.", source_command)
+                # execute_shell(source_command, **kwargs)
+            # except subprocess.CalledProcessError:
+                # log.info('Unable to find %s to copy.', s3_source_filename)
+            # else:
+                # try:
+                    # cmd = 'aws s3 cp s3://{bucket}/{src} {dest}'.format(
+                        # bucket=kwargs['pipeline_bucket'],
+                        # src=s3_source_filename,
+                        # dest=filename
+                    # )
+                    # # Define retries here, to recover from temporary outages when calling S3 to copy files.
+                    # local_kwargs = dict(**kwargs)
+                    # local_kwargs['max_tries'] = MAX_TRIES_FOR_COPY_FILE_FROM_S3
+                    # execute_shell(cmd, **local_kwargs)
+                # except subprocess.CalledProcessError:
+                    # log.error('Unable to copy %s to %s', s3_source_filename, filename)
+                    # raise
 
 
 class UserIDMapTask(CourseTask, SQLTask):


### PR DESCRIPTION
I want to update the version and set up of the edx-platform used by the analytics-exporter-master/worker jobs to match that of the analytics-exporter-course/email-optin jobs. However, to prevent it from clobbering anything in the currently running instances of the former, I have changed the worker code to bail before doing anything s3 related. This will prevent clobbering any partner data. Additionally, I have changed the naming structure of the temporary directories used locally to avoid clobbering anything while it is being processed.