### PR TITLE
pin opaque and ccx keys

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Application
 awscli
 docopt
-edx-ccx-keys
-edx-opaque-keys
+edx-ccx-keys==1.1.0 # Pinned for python 2.7 compatibility
+edx-opaque-keys==2.1.1 # Pinned for python 2.7 compatibility
 graphitesend==0.10.0 # Apache
 path.py
 pbr


### PR DESCRIPTION
edx-platform bumped to `openedx-calc to 2.0.0`, and made requirement python >=3.8.
As our export and email-optin jobs use 3.7, we are upgrading venv to 3.8 and needed to pin these packages to restrict them using to any latest/higher versions