### PR TITLE
Prevent the printing of secrets to the console when mongoexport fails

### DIFF
--- a/exporter/tasks.py
+++ b/exporter/tasks.py
@@ -173,7 +173,6 @@ class MongoTask(Task):
       --host {mongo_host}
       --db {mongo_db}
       --username {mongo_user}
-      --password "{mongo_password}"
       --collection {mongo_collection}
       --query '{query}'
       --slaveOk
@@ -195,7 +194,9 @@ class MongoTask(Task):
         if dry_run:
             print 'MONGO: {0}'.format(query)
         else:
-            execute_shell(cmd, **kwargs)
+            # For some reason, if mongoexport receives EOF before a newline, it panics.  So we need to add it manually:
+            stdin_string = kwargs['mongo_password'] + "\n"
+            execute_shell(cmd, stdin_string=stdin_string, **kwargs)
 
 
 class DjangoAdminTask(Task):


### PR DESCRIPTION
mongoexport assumes that stdin contains the password if the -p or
--password args are not provided, and there is no terminal available.
So, I changed the subprocess.check_call() to the more low-level
subprocess.Popen() and used it to pass a string to the subprocess stdin.
