### PR TITLE
feat: Specify columns from the auth_userprofile table

### DIFF
--- a/exporter/tasks.py
+++ b/exporter/tasks.py
@@ -464,24 +464,24 @@ class AuthUserProfileTask(CourseTask, SQLTask):
     NAME = 'auth_userprofile'
     SQL = """
     SELECT auth_userprofile.id,
-        1 as allow_certificate,
-        auth_userprofile.bio,
-        auth_userprofile.city,       
-        auth_userprofile.country,
+        auth_userprofile.user_id,
+        auth_userprofile.name,
+        auth_userprofile.language,
+        auth_userprofile.location,
+        auth_userprofile.meta,
         auth_userprofile.courseware,
         auth_userprofile.gender,
-        auth_userprofile.goals,
-        auth_userprofile.language,
-        auth_userprofile.level_of_education,
-        auth_userprofile.location,
         auth_userprofile.mailing_address,
-        auth_userprofile.meta,
-        auth_userprofile.name,
-        auth_userprofile.phone_number,
+        auth_userprofile.year_of_birth,
+        auth_userprofile.level_of_education,
+        auth_userprofile.goals,
+        1 as allow_certificate,
+        auth_userprofile.country,
+        auth_userprofile.city,       
+        auth_userprofile.bio,
         auth_userprofile.profile_image_uploaded_at,
-        auth_userprofile.state,
-        auth_userprofile.user_id,
-        auth_userprofile.year_of_birth
+        auth_userprofile.phone_number,
+        auth_userprofile.state
     FROM auth_userprofile
     INNER JOIN student_courseenrollment ON student_courseenrollment.user_id = auth_userprofile.user_id
     AND student_courseenrollment.course_id = '{course}'

--- a/exporter/tasks.py
+++ b/exporter/tasks.py
@@ -463,7 +463,25 @@ class AuthUserTask(CourseTask, SQLTask):
 class AuthUserProfileTask(CourseTask, SQLTask):
     NAME = 'auth_userprofile'
     SQL = """
-    SELECT auth_userprofile.*
+    SELECT auth_userprofile.id,
+        1 as allow_certificate,
+        auth_userprofile.bio,
+        auth_userprofile.city,       
+        auth_userprofile.country,
+        auth_userprofile.courseware,
+        auth_userprofile.gender,
+        auth_userprofile.goals,
+        auth_userprofile.language,
+        auth_userprofile.level_of_education,
+        auth_userprofile.location,
+        auth_userprofile.mailing_address,
+        auth_userprofile.meta,
+        auth_userprofile.name,
+        auth_userprofile.phone_number,
+        auth_userprofile.profile_image_uploaded_at,
+        auth_userprofile.state,
+        auth_userprofile.user_id,
+        auth_userprofile.year_of_birth
     FROM auth_userprofile
     INNER JOIN student_courseenrollment ON student_courseenrollment.user_id = auth_userprofile.user_id
     AND student_courseenrollment.course_id = '{course}'


### PR DESCRIPTION
Specify columns from the _auth_userprofile_ table, and select _allow_certificate_ as 1 (True).

This will allow _allow_certificate_ to continue to exist in the analytics pipeline even after it has been removed from the source db.

DESUPPORT-833 DEPR-140 MICROBA-985