### PR TITLE
feat: export all org and course data for single org [BB-5319]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
         os:
           - ubuntu-20.04
         python-version:
-          - 2.7
-        toxenv: [py27]
+          - 3.8
+        toxenv: [py38]
     steps:
       - uses: actions/checkout@v1
       - name: setup python

--- a/exporter/config.py
+++ b/exporter/config.py
@@ -59,7 +59,7 @@ def update_config(config, program_options):
 def merge_program_options(config, program_options):
     # get program options, removing '--' and replacing '-' with '_'
     options = {k[2:].replace('-', '_'): v for k, v
-               in program_options.iteritems()
+               in program_options.items()
                if k.startswith('--')}
 
     config['options'] = options
@@ -104,7 +104,7 @@ def update_environments(config):
     for env in ['prod', 'edge']:
         if env in environments:
             data = environments.get(env, {})
-            for config_name, token_name in field_map.iteritems():
+            for config_name, token_name in field_map.items():
                 data[config_name] = tokens.get(token_name)
 
             # different settings for edge
@@ -123,7 +123,7 @@ def update_organizations(config):
 
     # lowercase orgs before selection
     organizations = {org.lower(): values for org, values
-                     in config['organizations'].iteritems()}
+                     in config['organizations'].items()}
 
     # select only organizations in arguments
     organizations = filter_keys(organizations, values.get('org'))

--- a/exporter/course_export.py
+++ b/exporter/course_export.py
@@ -38,10 +38,10 @@ Options:
 from contextlib import contextmanager
 import datetime
 import os
-import subprocess
 import logging
 import logging.config
 import re
+import boto3
 
 from opaque_keys.edx.keys import CourseKey
 
@@ -110,23 +110,19 @@ def upload_files(config, results_directory):
     for filename in os.listdir(results_directory):
         filepath = os.path.join(results_directory, filename)
 
-        target = 's3://{bucket}/{prefix}{course}/state/{date}/{name}'.format(
-            bucket=bucket,
+        target = '{prefix}{course}/state/{date}/{name}'.format(
             prefix=prefix,
             course=filename_safe_course_id,
             date=output_date,
             name=filename
         )
 
-        log.info('Uploading file %s to %s', filepath, target)
-
-        cmd = 'aws s3 cp --acl bucket-owner-full-control {filepath} {target}'
-        cmd = cmd.format(filepath=filepath, target=target)
+        log.info('Uploading file %s to %s/%s', filepath, bucket, target)
 
         if not config['dry_run']:
-            subprocess.check_call(cmd, shell=True)
-        else:
-            log.info('cmd: %s', cmd)
+            s3_client = boto3.client('s3')
+            s3_client.upload_file(filepath, bucket, target)
+
 
 @contextmanager
 def make_course_directory(config, course):

--- a/exporter/course_export.py
+++ b/exporter/course_export.py
@@ -150,7 +150,7 @@ def get_filename_safe_course_id(course_id, replacement_char='_'):
     """
     try:
         course_key = CourseKey.from_string(course_id)
-        filename = unicode(replacement_char).join([course_key.org, course_key.course, course_key.run])
+        filename = replacement_char.join([course_key.org, course_key.course, course_key.run])
     except InvalidKeyError:
         # If the course_id doesn't parse, we will still return a value here.
         filename = course_id
@@ -158,4 +158,4 @@ def get_filename_safe_course_id(course_id, replacement_char='_'):
     # The safest characters are A-Z, a-z, 0-9, <underscore>, <period> and <hyphen>.
     # We represent the first four with \w.
     # TODO: Once we support courses with unicode characters, we will need to revisit this.
-    return re.sub(r'[^\w\.\-]', unicode(replacement_char), filename)
+    return re.sub(r'[^\w\.\-]', replacement_char, filename)

--- a/exporter/course_export.py
+++ b/exporter/course_export.py
@@ -121,7 +121,9 @@ def upload_files(config, results_directory):
 
         if not config['dry_run']:
             s3_client = boto3.client('s3')
-            s3_client.upload_file(filepath, bucket, target)
+            s3_client.upload_file(filepath, bucket, target, ExtraArgs={'ACL': 'bucket-owner-full-control'})
+        else:
+            log.info("Skipping file upload as running in dry run mode")
 
 
 @contextmanager

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -306,7 +306,7 @@ def get_all_courses(**kwargs):
 
     # make a set of fixed arguments, so we can memoize
     kwargs = {
-        k: v for k, v in kwargs.iteritems()
+        k: v for k, v in kwargs.items()
         if k.startswith('django') or k == 'lms_config' or k == 'studio_config'
     }
     kwargs['dry_run'] = False  # always query for course names

--- a/exporter/mysql_query.py
+++ b/exporter/mysql_query.py
@@ -59,4 +59,4 @@ class MysqlDumpQueryToTSV(object):
 
     def _normalize_value(self, value):
         if value is None: value='NULL'
-        return unicode(value).encode('utf-8').replace('\\', '\\\\').replace('\r', '\\r').replace('\t','\\t').replace('\n', '\\n')
+        return str(value).replace('\\', '\\\\').replace('\r', '\\r').replace('\t','\\t').replace('\n', '\\n')

--- a/exporter/properties.py
+++ b/exporter/properties.py
@@ -55,7 +55,7 @@ def export_properties(config, directory, files=None, orgs=None, prefix=''):
     recreate_directory(directory)
 
     orgs = [o.lower() for o in orgs.split()] if orgs else ['*']
-    print orgs
+    print(orgs)
 
     files_data = load_files(files)
 

--- a/exporter/single_org_config.py
+++ b/exporter/single_org_config.py
@@ -30,6 +30,8 @@ def _get_config(program_options):
     merge_program_options(config, program_options)
 
     update_exclude_tasks(config)
+    
+    update_include_tasks(config)
 
     set_config_defaults(config)
 
@@ -92,6 +94,17 @@ def update_exclude_tasks(config):
         del values['exclude_task']
 
     values['exclude_tasks'] = exclude_tasks
+
+def update_include_tasks(config):
+    values = config['values']
+
+    tasks = values.get('include_task', [])
+
+    if 'include_task' in values:
+        del values['include_task']
+
+    if tasks:
+        values['tasks'] = tasks
 
 
 def get_config_for_course(config, course):

--- a/exporter/single_org_config.py
+++ b/exporter/single_org_config.py
@@ -1,0 +1,126 @@
+# pylint: disable=missing-docstring
+
+import logging
+import logging.config
+import tempfile
+
+from docopt import docopt
+
+from exporter.util import merge, filter_keys
+
+log = logging.getLogger(__name__)
+
+
+def setup(doc, argv=None):
+    """
+    Setup export script with
+    config data provided as cli options
+    """
+    program_options = docopt(doc, argv=argv)
+    setup_logging()
+
+    log.info('Reading configuration')
+
+    return _get_config(program_options)
+
+
+def _get_config(program_options):
+    config = {}
+    
+    merge_program_options(config, program_options)
+
+    update_exclude_tasks(config)
+
+    set_config_defaults(config)
+
+    return config
+
+
+def set_config_defaults(config):
+    """
+    Set common default values if
+    not already set using cli options
+    """
+    values = config['values']
+
+    if not values.get('lms_config'):
+        values['lms_config'] = '/edx/etc/lms.yml'
+
+    if not values.get('studio_config'):
+        values['studio_config'] = '/edx/etc/studio.yml'
+
+    if not values.get('django_admin'):
+        values['django_admin'] = 'django-admin'
+
+    if not values.get('django_pythonpath'):
+        values['django_pythonpath'] = '/edx/app/edxapp/edx-platform'
+
+    values['name'] = values['environment']
+
+    if not values.get('output_prefix'):
+        values['output_prefix'] = values['organization']
+
+    values['exclude_tasks'] += [
+            'AssessmentCriterionTask', 
+            'AssessmentCriterionOptionTask', 
+            'AssessmentRubricTask', 
+            'AssessmentTrainingExampleTask', 
+            'AssessmentTrainingExampleOptionsSelectedTask'
+        ]
+
+
+def merge_program_options(config, program_options):
+    """
+    Get all the configs from CLI options
+    """
+    # get program options, removing '--' and replacing '-' with '_'
+    options = {k[2:].replace('-', '_'): v for k, v
+               in program_options.items()
+               if k.startswith('--')}
+
+    if not options.get('work_dir'):
+        options['work_dir'] = tempfile.gettempdir()
+
+    config['values'] = options
+
+def update_exclude_tasks(config):
+    values = config['values']
+
+    exclude_tasks = values.get('exclude_task', [])
+
+    if 'exclude_task' in values:
+        del values['exclude_task']
+
+    values['exclude_tasks'] = exclude_tasks
+
+
+def get_config_for_course(config, course):
+    course_config = merge(config['values'], {})
+    course_config['course'] = course
+    return course_config
+
+
+def setup_logging():
+    logging.config.dictConfig({
+        'version': 1,
+        'disable_existing_loggers': False,
+        'formatters': {
+            'standard': {
+                'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
+            }
+        },
+        'handlers': {
+            'default': {
+                'level': 'INFO',
+                'class': 'logging.StreamHandler',
+                'formatter': 'standard'
+            },
+        },
+        'loggers': {
+            '': {
+                'handlers': ['default'],
+                'level': 'INFO',
+                'propagate': True
+            }
+        }
+    })

--- a/exporter/single_org_export.py
+++ b/exporter/single_org_export.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python
+
+"""
+Export course data.
+
+Usage:
+  single-org-exporter [options] [--exclude-task=<task>...]
+
+Options:
+  -h --help                  Show this screen.
+  -n --dry-run               Don't run anything, just show what would be done.
+
+  --work-dir=<dir>           Working directory.
+
+  --limit=<limit>            Maximum number of results per file.
+
+  --output-bucket=<bucket>   Destination bucket.
+  --output-prefix=<pfx>      Prefix all output key names with this string.
+
+  --external-prefix=<pfx>    Prefix relative paths to external files with this string.
+  --pipeline-bucket=<pb>     Bucket that the EMR pipeline drops files in.
+  --environment=<name>       The enviornment name for which this is being run, ex. prod, stage
+
+  --django-admin=<admin>            The path to the appropriate django-admin.py
+  --django-pythonpath=<path>        The django python path
+  --django-settings=<settings>      The path to lms django settings file
+  --django-cms-settings=<settings>  The path to cms django settings file
+
+  --lms-config=<path>       The path to lms config yml file
+  --studio-config=<path>    The path to cms config yml file
+
+  --mongo-host=<host>               The mongo host to connect
+  --mongo-user=<username>           The mongo username to connect
+  --mongo-password=<password>       The mongo password to connect
+  --mongo-db=<db>                   The mongo db to query
+  --mongo-collection=<collection>   The mongo collection to query
+
+  --sql-host=<host>         The sql db host
+  --sql-user=<user>         The sql username for login to db
+  --sql-password=<password> The sql password for login to db
+  --sql-db=<db>             The sql db to query
+
+  --secret-key=<secert-key> The secret key to calculate user id hash
+
+  --organization=<org-name> The name of the organization
+
+  --exclude-task=<task>     Specify task NOT to run.
+"""
+
+
+from contextlib import contextmanager
+import datetime
+import os
+import logging
+import logging.config
+import re
+import shutil
+
+import boto3
+
+from opaque_keys.edx.keys import CourseKey
+from opaque_keys import InvalidKeyError
+
+from exporter.tasks import CourseTask, OrgTask
+from exporter.main import run_tasks, archive_directory, get_all_courses, _get_selected_tasks
+from exporter.single_org_config import setup, get_config_for_course
+from exporter.util import make_temp_directory, merge
+
+log = logging.getLogger(__name__)
+
+
+def main():
+    """
+    Fetch org data and course data for
+    given organization and upload data to S3
+    """
+    general_config = setup(__doc__)
+
+    courses = get_courses(general_config)
+
+    with make_org_directory(general_config) as temp_directory:
+        export_org_data(general_config, courses, temp_directory)
+
+        for course in courses:
+            config = get_config_for_course(general_config, course)
+            course_directory = os.path.join(temp_directory, get_filename_safe_course_id(course))
+            os.mkdir(course_directory)
+            export_course_data(config, course_directory)
+        
+        root_dir = archive_directory(temp_directory)
+        upload_files_or_dir(config, root_dir)
+
+
+def export_org_data(config, courses, destination):
+    """
+    Run tasks to fetch org data
+    """
+    kwargs = merge(config['values'], {})
+    kwargs['courses'] = courses
+    kwargs['work_dir'] = destination
+    tasks_from_options = kwargs.get('tasks', [])
+
+    org_tasks = _get_selected_tasks(OrgTask, tasks_from_options, [])
+    run_tasks(org_tasks, **kwargs)
+
+
+def get_courses(config):
+    """
+    Fetch a list of all courses
+    """
+    kwargs = merge(config['values'], {})
+    all_courses  = get_all_courses(**kwargs)
+
+    return all_courses
+
+
+def archive_directory(directory):
+    """
+    Create a single zip file
+    of all data files to be exported
+    """
+    root_dir = os.path.dirname(directory)
+    base_dir = os.path.basename(directory)
+
+    # Fix for error when running make_archive from crontab
+    os.chdir('/tmp')
+
+    shutil.make_archive(directory, 'zip', root_dir, base_dir)
+    shutil.rmtree(directory)
+
+    return root_dir
+
+
+def export_course_data(config, destination):
+    """
+    Run tasks to fetch course data for the
+    given course, except for the exculded tasks
+    and store the data in local files
+    """
+    log.info('Exporting data for %s', config['course'])
+
+    results = []
+
+    kwargs = merge(config, {})
+    kwargs['work_dir'] = destination
+
+    log.info("Getting data for course %s", config['course'])
+    tasks_from_options = kwargs.get('tasks', [])
+    exclude_tasks = kwargs.get('exclude_tasks', [])
+
+    course_tasks = _get_selected_tasks(CourseTask, tasks_from_options, exclude_tasks)
+
+    filenames = run_tasks(course_tasks, **kwargs)
+    results.extend(filenames)
+
+    return results
+
+def upload_files_or_dir(config, results_directory, sub_directory=None):
+    """
+    Upload all files in the provided directory
+    and all its sub-directories to S3
+    """
+    if sub_directory:
+        parent_directory = os.path.join(results_directory, sub_directory)
+    else:
+        parent_directory = results_directory
+
+    for filename in os.listdir(parent_directory):
+        filepath = os.path.join(parent_directory, filename)
+
+        if(os.path.isdir(filepath)):
+            upload_files_or_dir(config, results_directory, filename)
+        else:
+            if sub_directory:
+                filename = os.path.join(sub_directory, filename)
+            upload_file(config, filepath, filename)
+
+
+def upload_file(config, filepath, filename):
+    """
+    Upload given file to S3
+    """
+    bucket = config['output_bucket']
+    prefix = config.get('output_prefix', '')
+    
+    organization = config['organization']
+    output_date = str(datetime.date.today())
+
+    s3_target = '{prefix}_{org}/{date}/{name}'.format(
+        prefix=prefix,
+        org=organization,
+        date=output_date,
+        name=filename
+    )
+
+    target = f's3://{bucket}/{s3_target}'
+
+    log.info('Uploading file %s to %s', filepath, target)
+
+    if not config['dry_run']:
+        s3_client = boto3.client('s3')
+        s3_client.upload_file(filepath, bucket, s3_target)
+
+
+@contextmanager
+def make_org_directory(config):
+    """
+    Create a temporary directory in local
+    disk to store results of tasks
+    """
+    org_dir = config['values']['work_dir']
+    organization = config['values']['organization']
+
+    prefix = '{0}_'.format(organization)
+
+    with make_temp_directory(prefix=prefix, directory=org_dir) as temp_dir:
+        # create working directory
+        today = str(datetime.date.today())
+        dir_name = '{name}-{date}'.format(name=organization, date=today)
+        org_dir = os.path.join(temp_dir, dir_name)
+        os.mkdir(org_dir)
+
+        yield org_dir
+
+def get_filename_safe_course_id(course_id, replacement_char='_'):
+    """
+    Create a representation of a course_id that can be used safely in a filepath.
+    """
+    try:
+        course_key = CourseKey.from_string(course_id)
+        filename = replacement_char.join([course_key.org, course_key.course, course_key.run])
+    except InvalidKeyError:
+        # If the course_id doesn't parse, we will still return a value here.
+        filename = course_id
+
+    # The safest characters are A-Z, a-z, 0-9, <underscore>, <period> and <hyphen>.
+    # We represent the first four with \w.
+    return re.sub(r'[^\w\.\-]', replacement_char, filename)

--- a/exporter/single_org_export.py
+++ b/exporter/single_org_export.py
@@ -4,7 +4,7 @@
 Export course data.
 
 Usage:
-  single-org-exporter [options] [--exclude-task=<task>...]
+  single-org-exporter [options] [--exclude-task=<task>...] [--include-task=<task>...]
 
 Options:
   -h --help                  Show this screen.
@@ -34,6 +34,8 @@ Options:
   --mongo-password=<password>       The mongo password to connect
   --mongo-db=<db>                   The mongo db to query
   --mongo-collection=<collection>   The mongo collection to query
+  --mongo-auth-db=<auth-db>         The mongo auth db
+  --mongo-options=<options>         Mongo connection string options
 
   --sql-host=<host>         The sql db host
   --sql-user=<user>         The sql username for login to db
@@ -45,6 +47,8 @@ Options:
   --organization=<org-name> The name of the organization
 
   --exclude-task=<task>     Specify task NOT to run.
+
+  --include-task=<task>     Specify task to run. If nothing specified, all tasks are run.
 """
 
 

--- a/exporter/tasks.py
+++ b/exporter/tasks.py
@@ -175,11 +175,25 @@ class MongoTask(Task):
     @classmethod
     def constructMongoURI(*args, **kwargs):
         uri = "mongodb://"
-        
-        if kwargs.get("mongo_user") and kwargs.get("mongo_password"):
-            uri = f"{uri}{kwargs.get('mongo_user').strip()}:{kwargs.get('mongo_password').strip()}@"
 
-        return f"{uri}{kwargs.get('mongo_host')}/{kwargs.get('mongo_db')}"
+        mongo_host = kwargs.get('mongo_host')
+        mongo_user = kwargs.get('mongo_user')
+        mongo_password = kwargs.get('mongo_password')
+        mongo_auth_db = kwargs.get('mongo_auth_db')
+        mongo_options = kwargs.get('mongo_options')
+
+        if mongo_user and mongo_password:
+            uri = f"{uri}{mongo_user}:{mongo_password}@"
+
+        uri = f"{uri}{mongo_host}/"
+
+        if mongo_auth_db:
+            uri = f"{uri}{mongo_auth_db}"
+
+        if mongo_options:
+            uri = f"{uri}?{mongo_options}"
+
+        return uri
 
     @classmethod
     def run(cls, filename, dry_run, **kwargs):
@@ -191,10 +205,13 @@ class MongoTask(Task):
 
         log.debug(query)
 
+        mongo_db_name = kwargs.get("mongo_db")
+        mongo_collection = kwargs.get("mongo_collection")
+
         if dry_run:
             print('MONGO: {0}'.format(query))
         else:
-            collection = MongoClient(mongo_uri)[kwargs.get("mongo_db")][kwargs.get("mongo_collection")]
+            collection = MongoClient(mongo_uri)[mongo_db_name][mongo_collection]
             cursor = collection.find(json.loads(query))
             with open(filename, 'w') as file:
                 for document in cursor:

--- a/exporter/tasks.py
+++ b/exporter/tasks.py
@@ -142,7 +142,7 @@ class SQLTask(Task):
         log.debug(query)
 
         if dry_run:
-            print 'SQL: {0}'.format(query)
+            print('SQL: {0}'.format(query))
         else:
             mysql_query = MysqlDumpQueryToTSV(kwargs.get('sql_host'), kwargs.get('sql_user'), kwargs.get('sql_password'), kwargs.get('sql_db'), filename)
             mysql_query.execute(query)
@@ -192,7 +192,7 @@ class MongoTask(Task):
         cmd = cmd.format(filename=filename, query=query, **kwargs)
 
         if dry_run:
-            print 'MONGO: {0}'.format(query)
+            print('MONGO: {0}'.format(query))
         else:
             # For some reason, if mongoexport receives EOF before a newline, it panics.  So we need to add it manually:
             stdin_string = kwargs['mongo_password'] + "\n"
@@ -266,9 +266,9 @@ class CopyS3FileTask(Task):
         )
 
         if dry_run:
-            print 'Copy S3 File: {0} to {1}'.format(
+            print('Copy S3 File: {0} to {1}'.format(
                 s3_source_filename,
-                filename)
+                filename))
         else:
             # First check to see that the export data was successfully generated
             # by looking for a marker file for that run. Return a more severe failure,

--- a/exporter/tests/test_main.py
+++ b/exporter/tests/test_main.py
@@ -14,8 +14,8 @@ def test_get_selected_tasks_no_options_org_tasks():
 
 def test_get_selected_tasks_no_options_course_tasks():
     assert sorted([
-        task for task in tasks.DEFAULT_TASKS if issubclass(task, tasks.CourseTask)
-    ]) == sorted(main._get_selected_tasks(tasks.CourseTask, [], []))
+        task.__name__ for task in tasks.DEFAULT_TASKS if issubclass(task, tasks.CourseTask)
+    ]) == sorted(task.__name__ for task in main._get_selected_tasks(tasks.CourseTask, [], []))
 
 
 def test_get_selected_tasks_specified_from_options():
@@ -24,8 +24,8 @@ def test_get_selected_tasks_specified_from_options():
 
 def test_get_selected_tasks_excluded_tasks():
     assert sorted(
-        set(tasks.DEFAULT_TASKS) - set([tasks.OrgEmailOptInTask])
-    ) == sorted(main._get_selected_tasks(tasks.Task, [], ['OrgEmailOptInTask']))
+        task.__name__ for task in (set(tasks.DEFAULT_TASKS) - set([tasks.OrgEmailOptInTask]))
+    ) == sorted(task.__name__ for task in main._get_selected_tasks(tasks.Task, [], ['OrgEmailOptInTask']))
 
 
 def test_run_tasks_happy_path():

--- a/exporter/util.py
+++ b/exporter/util.py
@@ -51,7 +51,7 @@ def filter_keys(mapping, keys):
     if keys:
         result = {k: {} for k in keys}
         result.update({k: v for k, v
-                       in mapping.iteritems()
+                       in mapping.items()
                        if k in keys})
     else:
         result = mapping.copy()
@@ -165,8 +165,8 @@ def _retry_execute_shell(cmd, attempt, max_tries, popen_args, stdin_string=None)
         return 0
 
     if attempt >= max_tries:
-        print "Error: Command '{}' returned non-zero exit status {}".format(cmd, process.returncode)
-        print process.stderr
+        print("Error: Command '{}' returned non-zero exit status {}".format(cmd, process.returncode))
+        print(process.stderr)
         raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd, output=process.stderr)
 
     log.exception("Error occurred on attempt %d of %d", attempt, max_tries)

--- a/exporter/util.py
+++ b/exporter/util.py
@@ -193,3 +193,8 @@ def execute_shell(cmd, stdin_string=None, **kwargs):
         max_tries = 1
 
     return _retry_execute_shell(cmd, attempt, max_tries, popen_args, stdin_string=stdin_string)
+
+def exponential_delay_attempt(attempt):
+    exponential_delay = BASE_RETRY_DELAY_IN_SECONDS * (2 ** attempt)
+    log.info(f"Waiting {exponential_delay} seconds before attempting retry {attempt}")
+    time.sleep(exponential_delay)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Application
-awscli
+boto3
 docopt
 edx-ccx-keys
 edx-opaque-keys

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 # Application
 awscli
 docopt
-edx-ccx-keys==1.1.0 # Pinned for python 2.7 compatibility
-edx-opaque-keys==2.1.1 # Pinned for python 2.7 compatibility
+edx-ccx-keys
+edx-opaque-keys
 graphitesend==0.10.0 # Apache
 path.py
 pbr
-pip==1.5.6		# MIT // AN-4322
+pip
 pymongo
 python-dateutil
 python-gnupg==0.3.6
@@ -14,7 +14,7 @@ pyyaml
 psutil
 
 # Tests
-coverage==4.3.4
-mock==2.0.0
-pytest==3.0.7
-pytest-cov==2.4.0
+coverage
+mock
+pytest
+pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,4 @@ console_scripts =
     exporter-properties = exporter.properties:main
     exporter-check = exporter.check:main
     course-exporter = exporter.course_export:main
+    single-org-exporter = exporter.single_org_export:main

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27
+envlist = py38
 
 
 [testenv]


### PR DESCRIPTION
## Description

Currently there are two scripts to export data to S3 :
1. `main.py` : Encrypts and exports org data and all course data for multiple orgs using the org-specific configs for each org.
2. `course_export.py` : Exports data from specified tasks for specified courses. Does not export org data.

In our use-case, we need to export org data and all course data from open-edX `edx-platform` instance. The instance is configured and installed for a single org and the target S3 is also owned and accessed exclusively by that org.

Therefore, in this case there in no need to encrypt the data, or to support multiple orgs, which reduces and simplifies the configuration parameters needed to be provided to the export script

Furthermore, to make it easy for anyone using an ansible based open-edx installation to use this export script, this script needs to be installable using the [EDXAPP_EXTRA_REQUIREMENTS](https://github.com/openedx/configuration/blob/b0d081514f6beee40ff23fc79e2790bb91353700/playbooks/roles/edxapp/defaults/main.yml#L534) ansible variable and be run using a cron job configured using [EDXAPP_ADDITIONAL_CRON_JOBS](https://github.com/openedx/configuration/blob/b0d081514f6beee40ff23fc79e2790bb91353700/playbooks/roles/edxapp/defaults/main.yml#L913) ansible variable.

To achieve the above, 4 distinct changes are being proposed in this PR using 4 seperate commits to make it easier to review and to cherry pick the changes if so required. These are :
1. **Python3 compatibility** : The scripts in this repo are currently compatible with Python 2.x. This is a problem when installing it in the same virtual env as `edx-platform`. Thus all the scripts here were made compatilbe with python3. Also, the requirement version pins were removed from `requirements.txt`, since they conflicted with those of `edx-platform` and were no longer needed after migration to python3
2. **Migration from mongoexport to pymongo** : This was done to make the scripts independent of any external installations or dependencies. It is also easier to precisely configure, test and handle errors when using a python package instead using an external tool through CLI calls.
3. **Migration from awscli to boto3** : This was also done in the same spirit mentioned above.
4. **New script to export org data and all course data for single org** : This is a new script heavily inspired from the existing `main.py` and `course-export.py` scripts to export all org and course data for a single org. A new script was created so that the existing scripts are in no way affected, while being able to leverage all the existing data export tasks for the above mentioned use-case.

We believe, this PR could be quite useful for the wider open-edX community looking to configure and use these exporter scripts for their own installations.
