### PR TITLE
chore: Use gpg2 for importing gpg keys.

### DIFF
--- a/exporter/main.py
+++ b/exporter/main.py
@@ -69,7 +69,7 @@ log = logging.getLogger(__name__)
 
 # pylint: disable=missing-docstring
 
-
+GPGBINARY = 'gpg2'
 MAX_TRIES_FOR_DATA_UPLOAD = 5
 
 
@@ -171,7 +171,7 @@ def encrypt_files(config, filenames, temp_directory=None):
         recipients.append(config['gpg_master_key'])
 
     # user the temp directory, if specified, to store the keyring
-    gpg = gnupg.GPG(gnupghome=temp_directory)
+    gpg = gnupg.GPG(gpgbinary=GPGBINARY, gnupghome=temp_directory)
     gpg_key_dir = config['gpg_keys']
     gpg.encoding = 'utf-8'
 


### PR DESCRIPTION
The version of gnupg installed on Jenkins does not support  importing of keys with algos such as ECDSA.
This PR attempts to fix that by switching to gpg2 binary(current version on Jenkins: gpg (GnuPG) 2.1.11)