### PR TITLE
chore: use newly added management command to limit courses by end date

### DIFF
--- a/exporter/main.py
+++ b/exporter/main.py
@@ -307,10 +307,13 @@ def get_all_courses(**kwargs):
     # make a set of fixed arguments, so we can memoize
     kwargs = {
         k: v for k, v in kwargs.iteritems()
-        if k.startswith('django') or k == 'lms_config' or k == 'studio_config'
+        if k.startswith('django') or k == 'lms_config' or k == 'studio_config' or k == 'end'
     }
     kwargs['dry_run'] = False  # always query for course names
     kwargs['limit'] = False  # don't limit number of courses
+
+    if kwargs['end']:
+        kwargs['end'] = str(kwargs['end'])
 
     courses = _find_all_courses(**kwargs)
 

--- a/exporter/tasks.py
+++ b/exporter/tasks.py
@@ -953,8 +953,8 @@ class ForumsTask(CourseTask, MongoTask):
 class FindAllCoursesTask(DjangoAdminTask):
     NAME = 'courses'
     EXT = 'txt'
-    COMMAND = 'dump_course_ids'
-    ARGS = ''
+    COMMAND = 'dump_course_ids_with_filter'
+    ARGS = '--end {end}'
     OUT = '{filename}'
 
 


### PR DESCRIPTION
We can specify a default `end` value in the analytics-secure/analytics-exporter/default.yaml defaults like
```
defaults:
  end: 2018-01-01
```

Here is the link to the Platform PR: https://github.com/openedx/edx-platform/pull/30070 which adds in a new management command which accepts an argument `--end` to exclude all the courses which have ended before the given date. 
A separate management command is needed as the current `dump_course_ids` management command calls `CourseOverview.get_all_courses()` without any possible filtering. 