### PR TITLE
Use dump_course_ids_with_filter to limit courses by end date

### DIFF
--- a/exporter/properties.py
+++ b/exporter/properties.py
@@ -27,7 +27,7 @@ Options:
   --orgs=<orgs>            Space separated list of organization identifiers.
                            Can use wildcards.
 """
-
+from __future__ import print_function
 import os.path
 import shutil
 import sys
@@ -55,7 +55,7 @@ def export_properties(config, directory, files=None, orgs=None, prefix=''):
     recreate_directory(directory)
 
     orgs = [o.lower() for o in orgs.split()] if orgs else ['*']
-    print orgs
+    print(orgs)
 
     files_data = load_files(files)
 

--- a/exporter/tasks.py
+++ b/exporter/tasks.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-docstring
-
+from __future__ import print_function
 import logging
 import os
 import subprocess
@@ -142,7 +142,7 @@ class SQLTask(Task):
         log.debug(query)
 
         if dry_run:
-            print 'SQL: {0}'.format(query)
+            print('SQL: {0}'.format(query))
         else:
             mysql_query = MysqlDumpQueryToTSV(kwargs.get('sql_host'), kwargs.get('sql_user'), kwargs.get('sql_password'), kwargs.get('sql_db'), filename)
             mysql_query.execute(query)
@@ -192,7 +192,7 @@ class MongoTask(Task):
         cmd = cmd.format(filename=filename, query=query, **kwargs)
 
         if dry_run:
-            print 'MONGO: {0}'.format(query)
+            print('MONGO: {0}'.format(query))
         else:
             # For some reason, if mongoexport receives EOF before a newline, it panics.  So we need to add it manually:
             stdin_string = kwargs['mongo_password'] + "\n"
@@ -266,9 +266,9 @@ class CopyS3FileTask(Task):
         )
 
         if dry_run:
-            print 'Copy S3 File: {0} to {1}'.format(
+            print('Copy S3 File: {0} to {1}'.format(
                 s3_source_filename,
-                filename)
+                filename))
         else:
             # First check to see that the export data was successfully generated
             # by looking for a marker file for that run. Return a more severe failure,

--- a/exporter/tasks.py
+++ b/exporter/tasks.py
@@ -953,8 +953,8 @@ class ForumsTask(CourseTask, MongoTask):
 class FindAllCoursesTask(DjangoAdminTask):
     NAME = 'courses'
     EXT = 'txt'
-    COMMAND = 'dump_course_ids'
-    ARGS = ''
+    COMMAND = 'dump_course_ids_with_filter'
+    ARGS = '--end {end}'
     OUT = '{filename}'
 
 

--- a/exporter/util.py
+++ b/exporter/util.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-docstring
-
+from __future__ import print_function
 import atexit
 from contextlib import contextmanager
 import functools
@@ -165,8 +165,8 @@ def _retry_execute_shell(cmd, attempt, max_tries, popen_args, stdin_string=None)
         return 0
 
     if attempt >= max_tries:
-        print "Error: Command '{}' returned non-zero exit status {}".format(cmd, process.returncode)
-        print process.stderr
+        print("Error: Command '{}' returned non-zero exit status {}".format(cmd, process.returncode))
+        print(process.stderr)
         raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd, output=process.stderr)
 
     log.exception("Error occurred on attempt %d of %d", attempt, max_tries)
@@ -176,7 +176,7 @@ def _retry_execute_shell(cmd, attempt, max_tries, popen_args, stdin_string=None)
     time.sleep(exponential_delay)
 
     log.info("Retrying command: attempt %d", attempt)
-    return _retry_execute_shell(cmd, attempt, max_tries, **additional_args)
+    return _retry_execute_shell(cmd, attempt, max_tries, popen_args, stdin_string)
 
 
 def execute_shell(cmd, stdin_string=None, **kwargs):


### PR DESCRIPTION
This should have the exporter start using the `dump_course_ids_with_filter` management command added by [this platform PR](https://github.com/openedx/edx-platform/pull/30070) to limit the number of courses by their end dates. This is controlled by a `time_constraint` configuration value, which should be an integer used to calculate the lower bound for an end date.