### PR TITLE
chore: fix python3 data encoding issue

### DIFF
--- a/exporter/mysql_query.py
+++ b/exporter/mysql_query.py
@@ -59,4 +59,4 @@ class MysqlDumpQueryToTSV(object):
 
     def _normalize_value(self, value):
         if value is None: value='NULL'
-        return str(value).replace('\\', '\\\\').replace('\r', '\\r').replace('\t','\\t').replace('\n', '\\n').encode('utf-8')
+        return str(value).replace('\\', '\\\\').replace('\r', '\\r').replace('\t','\\t').replace('\n', '\\n')


### PR DESCRIPTION
When we migrated from python2 to python3 we used same encoding pattern that was in python2. I python3 when we encode data it converts it into bytes. For more explanation refer this doc https://bobbyhadz.com/blog/python-nameerror-name-unicode-is-not-defined