### PR TITLE
fix: replaced null character(\x00) to fix escaping error while writin…

### DIFF
--- a/exporter/mysql_query.py
+++ b/exporter/mysql_query.py
@@ -59,4 +59,4 @@ class MysqlDumpQueryToTSV(object):
 
     def _normalize_value(self, value):
         if value is None: value='NULL'
-        return str(value).replace('\\', '\\\\').replace('\r', '\\r').replace('\t','\\t').replace('\n', '\\n')
+        return str(value).replace('\\', '\\\\').replace('\r', '\\r').replace('\t','\\t').replace('\n', '\\n').replace('\x00', '')

--- a/exporter/tests/test_tasks.py
+++ b/exporter/tests/test_tasks.py
@@ -117,3 +117,16 @@ def test_course_task_get_filename_on_similar_names():
         kwargs['name'] = ('a' * 999) + 'b'
         file_name3 = os.path.basename(TestCourseTask.get_filename(**kwargs))
         assert len(set([file_name1, file_name2, file_name3])) == 3
+
+def test_normalize_value_with_null_character():
+    """
+    Test that a null character is removed from a string.
+    """
+    mysql_task = tasks.MysqlDumpQueryToTSV(
+        host='localhost',
+        username='root',
+        password='password',
+        database='test',
+        destination_filename='test.tsv',
+    )
+    assert mysql_task._normalize_value('abc\x00') == 'abc'


### PR DESCRIPTION
…g to csv.

Python 3's csv writer throws an error "need to escape, but no escapechar set" if there a null bytes in the string. 