### PR TITLE
chore: update python-gnupg version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pbr
 pip==19.2.3		
 pymongo
 python-dateutil
-python-gnupg==0.3.6
+python-gnupg==0.4.4
 pyyaml
 psutil
 


### PR DESCRIPTION
https://github.com/vsajip/python-gnupg/blob/bd69b80061fda77516b57bc1109405aa217e1342/README.rst#040
Bumping the version to fix the exporter throwing this error while encrypting:

```
06:28:01 Exception in thread Thread-16111:
06:28:01 Traceback (most recent call last):
06:28:01   File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
06:28:01     self.run()
06:28:01   File "/usr/lib/python3.8/threading.py", line 870, in run
06:28:01     self._target(*self._args, **self._kwargs)
06:28:01   File "/var/lib/jenkins/workspace/analytics-exporter-master/exporter_venv/lib/python3.8/site-packages/gnupg.py", line 741, in _read_response
06:28:01     result.handle_status(keyword, value)
06:28:01   File "/var/lib/jenkins/workspace/analytics-exporter-master/exporter_venv/lib/python3.8/site-packages/gnupg.py", line 518, in handle_status
06:28:01     Verify.handle_status(self, key, value)
06:28:01   File "/var/lib/jenkins/workspace/analytics-exporter-master/exporter_venv/lib/python3.8/site-packages/gnupg.py", line 275, in handle_status
06:28:01     raise ValueError("Unknown status message: %r" % key)
06:28:01 ValueError: Unknown status message: 'KEY_CONSIDERED'



